### PR TITLE
Version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # Compress
 
 Compresses any `.min.js` and `.min.css` files in the current folder (recursively).
-Any existing output files (`.br` or `.gz`) will always be recreated.
+Any existing output files (`.br`) will always be recreated.
 
 ## How to
 - Go to the folder that stores all your static assets (`.min.js` and `.min.css`)
 - execute `npx --no-install github:dgrammatiko/compress`
-- add the flag `-b` (eg: `npx --no-install github:dgrammatiko/compress -b`) to create both the `.br` and `.gz` files
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Compress
 
 Compresses any `.min.js` and `.min.css` files in the current folder (recursively).
-Any existing output files (`.br`) will always be recreated.
+Any existing output files (`.gz`) will always be recreated.
 
 ## How to
 - Go to the folder that stores all your static assets (`.min.js` and `.min.css`)

--- a/index.js
+++ b/index.js
@@ -1,16 +1,9 @@
 #!/usr/bin/env node
 "use strict";
-const { getFiles } = require('./src/getFiles.js');
-const { compressFile } = require('./src/compressFile.js');
+import { getFiles } from './src/getFiles.js';
+import { compressFile } from './src/compressFile.js';
 
-let enableBrotli = false;
-const args = process.argv.slice(2);
-
-if (['-b', '--brotli'].includes(args[0])) {
-  enableBrotli = true;
-}
-
-console.log(`Will compress files to .gz ${enableBrotli ? 'and .br' : ''}`);
+console.log('Will compress files to .gz');
 
 /**
  * Method to gzip the script and stylesheet files
@@ -19,12 +12,4 @@ console.log(`Will compress files to .gz ${enableBrotli ? 'and .br' : ''}`);
  *
  * @returns { void }
  */
-getFiles(`${process.cwd()}/`)
-  .then(async files => {
-    for (const file of files) {
-      await compressFile(file, enableBrotli);
-    }
-
-    console.log('Done 👍');
-  })
-  .catch(err => process.exit(err ? 1 : 0));
+getFiles(`${process.cwd()}/`).then(files => files.forEach(file => compressFile(file))).catch(err => process.exit(err ? 1 : 0));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,194 @@
+{
+  "name": "@dgrammatiko/compress",
+  "version": "2.0.0-alpha1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dgrammatiko/compress",
+      "version": "2.0.0-alpha1",
+      "license": "MIT",
+      "dependencies": {
+        "@hpcc-js/wasm": "^2.8.0"
+      },
+      "bin": {
+        "compress": "index.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@hpcc-js/wasm": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-2.8.0.tgz",
+      "integrity": "sha512-u/VO0IeZ5RpbstGJ56XH1TOlB0fv/CSHGFqoHZ06yyTBxcyVjTVjZyU9qYidjIOI7Y1ZGOAj4k5vBi03/vZhdg==",
+      "dependencies": {
+        "yargs": "17.6.2"
+      },
+      "bin": {
+        "dot-wasm": "bin/dot-wasm.js"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@dgrammatiko/compress",
-  "version": "1.0.3",
-  "description": "Compresses any `.min.js` and `.min.css` files in the current folder (recursively). Any existing output files (`.br` or `.gz`) will always be recreated.",
+  "version": "2.0.0-alpha1",
+  "description": "Compresses any `.min.js` and `.min.css` files in the current folder (recursively). Any existing output files (`.gz`) will always be recreated.",
+  "type": "module",
   "main": "index.js",
   "engines": {
-    "node": "^10.16.0 || >=11.7.0"
+    "node": ">=18.0.0"
   },
   "bin": {
     "compress": "index.js"
@@ -21,5 +22,8 @@
   "homepage": "https://github.com/dgrammatiko/compress#readme",
   "scripts": {
     "compress": "node index.js"
+  },
+  "dependencies": {
+    "@hpcc-js/wasm": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrammatiko/compress",
-  "version": "2.0.0-alpha1",
+  "version": "2.0.0",
   "description": "Compresses any `.min.js` and `.min.css` files in the current folder (recursively). Any existing output files (`.gz`) will always be recreated.",
   "type": "module",
   "main": "index.js",

--- a/src/compressFile.js
+++ b/src/compressFile.js
@@ -1,10 +1,10 @@
-import { readFile, writeFile } from 'fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { Zstd } from "@hpcc-js/wasm/zstd";
 
 const zstd = await Zstd.load();
 const compressionLevel = 19;
 
-export async function compressFile(file) {
+async function compressFile(file) {
   if (file.endsWith('.min.js') || file.endsWith('.min.css')) {
       try {
         const data = await readFile(file);
@@ -15,3 +15,5 @@ export async function compressFile(file) {
       }
   }
 }
+
+export {compressFile};

--- a/src/getFiles.js
+++ b/src/getFiles.js
@@ -1,12 +1,12 @@
-import { readdir } from 'fs/promises';
-import { extname } from 'path';
+import { readdir } from 'node:fs/promises';
+import { extname } from 'node:path';
 
 /**
  * Get files recursively
  *
  * @param {string} path The path
  */
-export async function getFiles(path) {
+async function getFiles(path) {
   const entries = await readdir(path, { withFileTypes: true });
 
   // Get files within the current directory
@@ -24,3 +24,5 @@ export async function getFiles(path) {
 
   return files;
 }
+
+export {getFiles};

--- a/src/getFiles.js
+++ b/src/getFiles.js
@@ -1,12 +1,12 @@
-const { readdir } = require('fs').promises;
-const { extname } = require('path');
+import { readdir } from 'fs/promises';
+import { extname } from 'path';
 
 /**
  * Get files recursively
  *
  * @param {string} path The path
  */
-async function getFiles(path) {
+export async function getFiles(path) {
   const entries = await readdir(path, { withFileTypes: true });
 
   // Get files within the current directory
@@ -24,5 +24,3 @@ async function getFiles(path) {
 
   return files;
 }
-
-module.exports.getFiles = getFiles;


### PR DESCRIPTION
- Use zstd instead of the node gzip
- Compression level = 19

Why Zstd?

- browsers are going to natively support it https://github.com/Fyrd/caniuse/issues/4065
- the decompression is faster than both Brotli and GZip: https://twitter.com/jarredsumner/status/1554363277756420096

